### PR TITLE
Update to json-refs 2.1.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,48 +1,27 @@
 var es = require("event-stream");
 var clone = require("clone");
 var JsonRefs = require("json-refs");
-var YAML = require("yaml-js");
-
-function getJsonMatch (filePath) {
-  if (typeof filePath === "string") {
-    return filePath.match(/\.json$/);
-  }
-}
-
-function getYamlMatch (filePath) {
-  if (typeof filePath === "string") {
-    return filePath.match(/\.yaml$/);
-  }
-}
+var YAML = require("js-yaml");
 
 module.exports = function(opts) {
   "use strict";
   opts = opts || {};
 
   function resolveRefs(file, callback) {
-    var options = clone(opts),
-        fileContents;
+    var options = clone(opts);
 
     if (file.isNull()) {
       return callback(null, file);
     }
 
-    // Parse YAML or JSON, depending on settings
-    if (options.yaml && getYamlMatch(file.path)) {
-      fileContents = YAML.load(file.contents);
-    } else if (getJsonMatch(file.path)) {
-      fileContents = JSON.parse(file.contents);
-    } else {
-      return callback(null, file);
-    }
+    options.loaderOptions = {
+        processContent: function (res, callback) {
+          callback(undefined, YAML.safeLoad(res.text));
+        }
+    };
 
-    // If location not specified, set it to the file's folder for relative references to work
-    if (!options.location) {
-      options.location = file.path.split("/").slice(0,-1).join("/");
-    }
-
-    JsonRefs.resolveRefs(fileContents, options).then(function (results) {
-      var output = (options.yaml) ? YAML.dump(results.resolved) : JSON.stringify(results.resolved);
+    JsonRefs.resolveRefsAt(file.path, options).then(function (results) {
+      var output = (options.yaml) ? YAML.safeDump(results.resolved, {noRefs: true}) : JSON.stringify(results.resolved);
       file.contents = new Buffer(output);
       callback(null, file);
     }, function (error) {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "clone": "^1.0.2",
     "event-stream": "^3.3.1",
-    "json-refs": "^1.0.2",
-    "yaml-js": "^0.1.3"
+    "js-yaml": "^3.5.2",
+    "json-refs": "^2.1.5"
   },
   "devDependencies": {
     "assert": "^1.3.0",

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var gulpJsonRefs = require("../index.js");
 var es = require("event-stream");
 var path = require("path");
 var assert = require("assert");
-var YAML = require("yaml-js");
+var YAML = require("js-yaml");
 
 require("mocha");
 
@@ -83,7 +83,7 @@ describe("gulp-json-refs", function() {
       gulp.src(path.join(__dirname, "./fixtures/same-file-reference.yaml"))
         .pipe(gulpJsonRefs({ "yaml": true }))
         .pipe(compareResults(done, {
-          expected: YAML.dump({
+          expected: YAML.safeDump({
             "name": {
               "first": "Bob",
               "last": "Loblaw"
@@ -100,7 +100,7 @@ describe("gulp-json-refs", function() {
       gulp.src(path.join(__dirname, "./fixtures/local-file-reference.yaml"))
         .pipe(gulpJsonRefs({ "yaml": true }))
         .pipe(compareResults(done, {
-          expected: YAML.dump({
+          expected: YAML.safeDump({
             "author": {
               "first": "Bob",
               "last": "Loblaw"
@@ -113,7 +113,7 @@ describe("gulp-json-refs", function() {
       gulp.src(path.join(__dirname, "./fixtures/refer-to-reference.yaml"))
         .pipe(gulpJsonRefs({ "yaml": true }))
         .pipe(compareResults(done, {
-          expected: YAML.dump({
+          expected: YAML.safeDump({
             "title": "json",
             "author": {
               "first": "Bob",
@@ -127,20 +127,12 @@ describe("gulp-json-refs", function() {
       gulp.src(path.join(__dirname, "./fixtures/remote-reference.yaml"))
         .pipe(gulpJsonRefs({ "yaml": true }))
         .pipe(compareResults(done, {
-          expected: YAML.dump({
+          expected: YAML.safeDump({
             "name": "json-refs",
             "owner": "whitlockjc"
           })
         }));
     });  });
-
-  it ("should accept a non-JSON / non-YAML file but do nothing to it", function (done) {
-    gulp.src(path.join(__dirname, "./fixtures/invalid-json.html"))
-      .pipe(gulpJsonRefs())
-      .pipe(compareResults(done, {
-        expected: "<p>This is not JSON</p>"
-      }));
-  });
 });
 
 // Use cases


### PR DESCRIPTION
The old json-refs is missing a lot of functionality that the new one provides.  It actually makes it a lot easier to use as well.  I took the code being used here from the CLI command that json-refs now ships with so things will work with gulp in much the same way as they work with the json-refs CLI.
